### PR TITLE
Fixed Makefiles to reflect new benchmark IP hierarchy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ ip_repo/benchmark_ips/*
 !ip_repo/benchmark_ips/Makefile
 !ip_repo/benchmark_ips/scripts
 !ip_repo/benchmark_ips/scripts/*
+
+# ignore vivado log files
+**/vivado*

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ loopback_example: GULF_Stream_IPCore
 	$(MAKE) -C examples loopback_server
 
 benchmark_example: GULF_Stream_IPCore
-	$(MAKE) -C ip_repo/benchmark_ips
+	$(MAKE) -C ip_repo/assembled_ips GULF_Stream_benchmark
 	$(MAKE) -C examples benchmark
 
 clean_all:

--- a/ip_repo/assembled_ips/Makefile
+++ b/ip_repo/assembled_ips/Makefile
@@ -16,9 +16,9 @@ udp_ip_server_100g: scripts/udp_ip.tcl ../hls_ips/udp_ip_server
 	rm -rf udp_ip_server_100g
 	vivado -mode tcl -source scripts/udp_ip.tcl -nolog -nojournal
 
-GULF_Stream_benchmark: ../hls_ips/payload_generator ../hls_ips/payload_validator ../hls_ips/PSInterface scripts/GULF_Stream_benchmark.tcl
+GULF_Stream_benchmark: ../hls_ips/benchmark/payload_generator ../hls_ips/benchmark/payload_validator ../hls_ips/benchmark/PSInterface scripts/GULF_Stream_benchmark.tcl
 	rm -rf GULF_Stream_benchmark
 	vivado -mode tcl -source scripts/GULF_Stream_benchmark.tcl -nolog -nojournal
 
 clean:
-	rm -rf arp_server_100g lbus_axis_converter udp_ip_server_100g GULF_Stream
+	rm -rf GULF_Stream arp_server_100g lbus_axis_converter udp_ip_server_100g GULF_Stream_benchmark

--- a/ip_repo/hls_ips/Makefile
+++ b/ip_repo/hls_ips/Makefile
@@ -1,4 +1,4 @@
-all: arp_server lbus_axis_converter ether_protocol_assembler ether_protocol_spliter udp_ip_server payload_generator payload_validator PSInterface
+all: arp_server lbus_axis_converter ether_protocol_assembler ether_protocol_spliter udp_ip_server benchmark
 
 arp_server: scripts/arp_server/* ../../src/arp_server/*
 	rm -rf arp_server


### PR DESCRIPTION
I fixed the Makefile bugs that were popping up when making the example projects as well as added Vivado logs to the .gitignore.

There were a few things I couldn't make work that I wanted to add but didn't want to keep messing with because testing takes forever:
1. remove 'benchmark' from 'all' in ip_repo/hls_ips (this worked)
2. add 'benchmark' to 'benchmark_example' in main Makefile (this caused an error when importing payload_validator and payload_generator in Vivado)
3. add ~~example clean~~ assembled_ips clean to main Makefile (this worked)